### PR TITLE
Mark this repository as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# DEPRECATED
+
+This repository is being deprecated in favour of the appropriate [Helm charts](https://github.com/esl/MongooseHelm). If you want to recover the plain kubernetes yaml definitions, it can be done using the `helm template` command on the supported helm repository, where you can find the appropriate information on how to do so.
+
 # MongooseIM in Kubernetes
 
 This repository contains a [StatefulSet][sts] definition describing a simple yet

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# DEPRECATED
+# We have moved!
 
-This repository is being deprecated in favour of the appropriate [Helm charts](https://github.com/esl/MongooseHelm). If you want to recover the plain kubernetes yaml definitions, it can be done using the `helm template` command on the supported helm repository, where you can find the appropriate information on how to do so.
+We have switched from direct use of Kubernetes resource files to [Helm charts](https://github.com/esl/MongooseHelm). The already existing resource files are still kept here for reference. If you want to recover them from the Helm Charts, it can be done using the `helm template` command on the supported Helm repository. You can find more detailed instructions there. This repository will be archived.
 
 # MongooseIM in Kubernetes
 


### PR DESCRIPTION
Once this is merge, I'll also mark the repository as archived and change the github description to link to the new helm repo.